### PR TITLE
Update to New OS Mapping

### DIFF
--- a/vmware-tools/defaults.yaml
+++ b/vmware-tools/defaults.yaml
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+vmware_tools:
+  latest: 'VMwareTools-9.4.15-2827462.tar.gz'
+  hash: 'md5=6d46188024553a4576977b54caae5403'
+  source: 'http://webserver/Latest_VMware_Tools/VMwareTools-9.4.15-2827462.tar.gz'

--- a/vmware-tools/init.sls
+++ b/vmware-tools/init.sls
@@ -1,7 +1,7 @@
 {% if 'VMWare' in grains['virtual'] or 'VMware' in grains['virtual'] %}
-{% from "vmware-tools/map.jinja" import config with context %}
+{% from "vmware-tools/map.jinja" import vmware with context %}
 
 include:
-  - vmware-tools.{{ config.include }}
+  - vmware-tools.{{ vmware.include }}
 
 {% endif %}

--- a/vmware-tools/map.jinja
+++ b/vmware-tools/map.jinja
@@ -1,51 +1,21 @@
-# Set defaults since deploying from sources
-{% set vmware_defaults = {
-  'tools':
-  {
-    'latest': 'VMwareTools-9.4.15-2827462.tar.gz',
-    'hash': 'md5=6d46188024553a4576977b54caae5403',
-    'source': 'http://webserver/Latest_VMware_Tools/VMwareTools-9.4.15-2827462.tar.gz',
-  },
-} %}
+{# vi: set ft=jinja: #}
 
-# Merge the default settings with pillar data
-{% set vmware = salt['pillar.get']('vmware:tools', default=vmware_defaults.tools,merge=True) %}
+{% import_yaml "vmware-tools/defaults.yaml" as defaults %}
+{% import_yaml "vmware-tools/osfamilymap.yaml" as osfamilymap %}
+{% import_yaml "vmware-tools/oscodenamemap.yaml" as oscodenamemap %}
+{% import_yaml "vmware-tools/osfingermap.yaml" as osfingermap %}
 
-# Get the settings for the osmajorrelease grain
-{% set os_ver_lookup = {
-  'RedHat':
-  {
-    7:
-    {
-      'include': 'open-vm-tools',
-      'package': 'open-vm-tools',
-      'service': 'vmtoolsd',
-    },
-    6:
-    {
-      'include': 'vmware-tools',
-    }
-  },
-  'Debian':
-  {
-    9:
-    {
-      'include': 'open-vm-tools',
-      'package': 'open-vm-tools',
-      'service': 'open-vm-tools',
-    }
-  },
-  'Ubuntu':
-  {
-    18:
-    {
-      'include': 'open-vm-tools',
-      'package': 'open-vm-tools',
-      'service': 'open-vm-tools',
-    }
-  }
-} %}
+{# merge the osfamily map #}
+{% set osfamily = salt['grains.filter_by'](osfamilymap, grain='os_family') or{} %}
+{% do defaults.vmware_tools.update(osfamily) %}
 
-{% set os_map = os_ver_lookup.get(grains.os, {}) %} 
-{% set osrelease = salt['grains.get']('osmajorrelease') | int %}
-{% set config = os_map.get(osrelease, {}) %} 
+{# merge oscodenameswap #}
+{% set oscode = salt['grains.filter_by'](oscodenamemap, grain='oscodename') or {} %}
+{% do defaults.vmware_tools.update(oscode) %}
+
+{# merge the osfingermap #}
+{% set osfinger = salt['grains.filter_by'](osfingermap, grain='osfinger') or {} %}
+{% do defaults.vmware_tools.update(osfinger) %}
+
+{# merge all #}
+{% set vmware = salt['pillar.get']('vmware:tools', default=defaults['vmware_tools'], merge=True) %}

--- a/vmware-tools/map.jinja
+++ b/vmware-tools/map.jinja
@@ -34,9 +34,18 @@
       'package': 'open-vm-tools',
       'service': 'open-vm-tools',
     }
+  },
+  'Ubuntu':
+  {
+    18:
+    {
+      'include': 'open-vm-tools',
+      'package': 'open-vm-tools',
+      'service': 'open-vm-tools',
+    }
   }
 } %}
 
-{% set os_map = os_ver_lookup.get(grains.os_family, {}) %} 
+{% set os_map = os_ver_lookup.get(grains.os, {}) %} 
 {% set osrelease = salt['grains.get']('osmajorrelease') | int %}
 {% set config = os_map.get(osrelease, {}) %} 

--- a/vmware-tools/open-vm-tools.sls
+++ b/vmware-tools/open-vm-tools.sls
@@ -1,10 +1,10 @@
-{% from "vmware-tools/map.jinja" import config with context %}
+{% from "vmware-tools/map.jinja" import vmware with context %}
 package-install-open-vm-tools:
   pkg.installed:
     - pkgs:
-      - {{ config.package }}
+      - {{ vmware.package }}
 
 service-open-vm-tools:
   service.running:
-    - name: {{ config.service }}
+    - name: {{ vmware.service }}
     - enable: True

--- a/vmware-tools/oscodenamemap.yaml
+++ b/vmware-tools/oscodenamemap.yaml
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+trusty:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+utopic:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+vivid:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+wily:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+xenial:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+yakkety:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+zesty:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+artful:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+bionic:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+jessie:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+stretch:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+buster:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools

--- a/vmware-tools/osfamilymap.yaml
+++ b/vmware-tools/osfamilymap.yaml
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+Debian:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: open-vm-tools
+
+RedHat:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: vmtoolsd
+
+Suse:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: vmtoolsd
+
+Arch:
+  include: open-vm-tools
+  package: open-vm-tools
+  service: vmtoolsd

--- a/vmware-tools/osfingermap.yaml
+++ b/vmware-tools/osfingermap.yaml
@@ -1,0 +1,40 @@
+default:
+  include: 'open-vm-tools'
+  package: 'open-vm-tools'
+  service: 'vmtoolsd'
+
+Ubuntu-12.04:
+  include: 'vmware-tools'
+
+Ubuntu-14.04:
+  service: 'open-vm-tools'
+
+Ubuntu-16.04:
+  service: 'open-vm-tools'
+
+Ubuntu-18.04:
+  service: 'open-vm-tools'
+
+Red Hat Enterprise Linux Server-6:
+  include: 'vmware-tools'
+
+Red Hat Enterprise Linux Server-7:
+  include: 'open-vm-tools'
+  package: 'open-vm-tools'
+  service: 'vmtoolsd'
+
+CentOS-6:
+  include: 'vmware-tools'
+
+CentOS-7:
+  include: 'open-vm-tools'
+  package: 'open-vm-tools'
+  service: 'vmtoolsd'
+
+Oracle Linux Server-6:
+  include: 'vmware-tools'
+
+Oracle Linux Server-7:
+  include: 'open-vm-tools'
+  package: 'open-vm-tools'
+  service: 'vmtoolsd'


### PR DESCRIPTION
Changes:

  This moves the vmware-tools formula to a new OS mapping, similar to what is used within the apache-formula.

Testing:
  I was able to test these new changes on RHEL 6, RHEL 7, and Ubuntu 18.04.

If you want me to do some more testing on other machines, let me know and I will see what I can do.